### PR TITLE
Rename to "sqlalchemy-libsql"

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
-name = "libsql-sqlalchemy"
-version = "0.1.0"
+name = "sqlalchemy-libsql"
+version = "0.2.0-pre.1"
 description = "SQLAlchemy dialect for libSQL"
 readme = "README.md"
 requires-python = ">=3.12"


### PR DESCRIPTION
No reason to create a new Python package. Let's just use the existing "sqlalchemy-libsql" name, but bump it as 0.2.0-pre.1.